### PR TITLE
Allow customization of the Guzzle client

### DIFF
--- a/src/InsightsCaller.php
+++ b/src/InsightsCaller.php
@@ -31,10 +31,11 @@ class InsightsCaller
      *
      * @param string $apiKey
      * @param string $locale
+     * @param array $config
      */
-    public function __construct($apiKey, $locale = 'en')
+    public function __construct($apiKey, $locale = 'en', $config = array())
     {
-        $this->client = new Client();
+        $this->client = new Client($config);
         $this->apiKey = $apiKey;
         $this->locale = $locale;
         $this->captureScreenshot = true;


### PR DESCRIPTION
In environments where a certificate authority bundle is not available or configured, this package will fail with an error:

```
cURL error 60: SSL certificate problem: unable to get local issuer certificate
```

Since this issue can't be fixed on the server side in some cases (e.g. shared hosting), I added a `$config` parameter to the constructor allowing us to pass Guzzle options, including a certificate authority bundle:

```php
$caller = new InsightsCaller($key, 'en', ['verify' => '/path/to/cacert.pem']);
```